### PR TITLE
Add UI guidelines and dark dashboard layout

### DIFF
--- a/Hexagon/Views/Shared/_DashboardLayout.cshtml
+++ b/Hexagon/Views/Shared/_DashboardLayout.cshtml
@@ -1,0 +1,23 @@
+@* Dashboard layout with sidebar navigation *@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@ViewData["Title"] - Hexagon</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="~/css/output.css" asp-append-version="true" />
+</head>
+<body class="font-sans bg-slate-900 text-gray-200 min-h-screen flex">
+    <aside class="w-64 p-4 space-y-2 bg-white/10 backdrop-blur-lg hidden md:block">
+        <nav class="space-y-1">
+            <a asp-controller="Home" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-pink/20">Dashboard</a>
+            <a asp-controller="Users" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-violet/20">Users</a>
+            <a asp-controller="Products" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-cyan/20">Products</a>
+        </nav>
+    </aside>
+    <main class="flex-1 p-6">
+        @RenderBody()
+    </main>
+</body>
+</html>

--- a/Hexagon/tailwind.config.js
+++ b/Hexagon/tailwind.config.js
@@ -1,10 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    content: [
-        './Views/**/*.cshtml', // Razor
-        './wwwroot/**/*.html', // HTML
-        './Scripts/**/*.js',    // JavaScript
-    ],
+  darkMode: 'class',
+  content: [
+    './Views/**/*.cshtml', // Razor
+    './wwwroot/**/*.html', // HTML
+    './Scripts/**/*.js',   // JavaScript
+  ],
   theme: {
     extend: {
       fontFamily: {

--- a/Hexagon/wwwroot/css/site.css
+++ b/Hexagon/wwwroot/css/site.css
@@ -12,6 +12,8 @@
   --python-color: #FFD43B;
   --csharp-color: #9B4F96;
   --js-color: #F0DB4F;
+  --background-dark: #0f172a;
+  --foreground-dark: #e2e8f0;
 }
 
 .glass {
@@ -19,6 +21,11 @@
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.dark .glass {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
 }
 
 /* Background gradient utilities */
@@ -39,4 +46,9 @@
 }
 .bg-gradient-js {
   background: linear-gradient(45deg, var(--js-color), var(--accent-2));
+}
+
+body.dark {
+  background-color: var(--background-dark);
+  color: var(--foreground-dark);
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Hexagon UI Guidelines
+
+This document outlines the design principles used for the Razor MVC application in this repository.
+
+## Theme
+
+- **Dark base** with contrasting text and UI elements.
+- Vibrant accent colors are defined in `tailwind.config.js` as `accent.pink`, `accent.violet` and `accent.cyan`.
+- Glassmorphism is provided with the `.glass` utility in `site.css`.
+- Dark mode is enabled via `class="dark"` on the `<html>` element.
+
+## Layout
+
+- Top navigation implemented in `_Layout.cshtml` with floating animated circles for visual interest.
+- Responsive layout uses Tailwind CSS classes. The site font is `Inter`.
+
+## Components
+
+- Cards and detail sections use `bg-white` on a dark background to create contrast.
+- Animations rely on custom keyframes defined in Tailwind (see the `float` animation).
+
+## Example sidebar layout
+
+```
+@*
+    Views/Shared/_DashboardLayout.cshtml
+*@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@ViewData["Title"] - Hexagon</title>
+    <link rel="stylesheet" href="~/css/output.css" asp-append-version="true" />
+</head>
+<body class="font-sans bg-slate-900 text-gray-200 min-h-screen flex">
+    <aside class="w-64 p-4 space-y-2 bg-white/10 backdrop-blur-lg hidden md:block">
+        <nav class="space-y-1">
+            <a asp-controller="Home" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-pink/20">Dashboard</a>
+            <a asp-controller="Users" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-violet/20">Users</a>
+            <a asp-controller="Products" asp-action="Index" class="block px-2 py-1 rounded hover:bg-accent-cyan/20">Products</a>
+        </nav>
+    </aside>
+    <main class="flex-1 p-6">
+        @RenderBody()
+    </main>
+</body>
+</html>
+```
+
+This layout demonstrates a sidebar that can be reused for dashboard pages when working with Entity Framework entities.
+
+## Usage
+
+Run `npm run build:css` to regenerate `wwwroot/css/output.css` after modifying `site.css` or `tailwind.config.js`.
+


### PR DESCRIPTION
## Summary
- document UI theme in a new README
- enable Tailwind dark mode
- extend custom CSS variables and styles
- add an example dashboard layout with a sidebar

## Testing
- `npm run build:css` *(fails: Browserslist data out of date, watch mode started)*
- `dotnet build Hexagon.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443b29a2e0832c8d44593b73a5a4da